### PR TITLE
Stop recording at (re)deploy

### DIFF
--- a/micropi/nodes/microphone/microphone.js
+++ b/micropi/nodes/microphone/microphone.js
@@ -37,6 +37,10 @@ module.exports = function(RED) {
             this.stopRecord();
         }
     });
+    
+    this.on('close', function() {
+        this.stopRecord();
+    });
 
     this.startRecord = function(timeout) {
         mic.start(node, timeout);

--- a/micropi/nodes/micropi/micropi.js
+++ b/micropi/nodes/micropi/micropi.js
@@ -37,6 +37,10 @@ module.exports = function(RED) {
             this.stopRecord();
         }
     });
+    
+    this.on('close', function() {
+        this.stopRecord();
+    });
 
     this.startRecord = function(timeout) {
         mic.start(node, timeout);


### PR DESCRIPTION
Hi Markus (@MarkusWals),

Thanks for this nice contribution!

I added a small change, to stop recording when the Node-RED flow is (re)deployed, to make sure users can start from scratch.

Thanks a lot !!
Bart Butenaers